### PR TITLE
Added RPM metadata

### DIFF
--- a/ConfigurePackaging.cmake
+++ b/ConfigurePackaging.cmake
@@ -140,6 +140,9 @@ macro(SetPackageMetadata)
         ${CMAKE_CURRENT_BINARY_DIR}/MAC_PACKAGE_INTRO.txt)
 
     set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+    set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
+    set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /opt /var /var/opt)
+    set(CPACK_RPM_PACKAGE_REQUIRES "libpcap, openssl-libs, bind-libs, zlib, bash, python, libcurl, gawk, GeoIP")
 endmacro(SetPackageMetadata)
 
 # Sets pre and post install scripts for PackageMaker packages.


### PR DESCRIPTION
Added some additional RPM metadata which is critical to function on EL7 or Fedora 20 or greater (possibly earlier Fedora, but not sure). The most critical line here is line 144, which excludes system-owned directories. Without this, RPMs must be manually force installed. Adding the dependency list will make the RPMs more portable and can ensure the dependencies are installed if someone installs the RPM with yum. I'm not sure the base dependencies used for the package distributed on bro.org, but this is what I use.

Also see my gist for otherwise specific directions to build on EL7 variants: https://gist.github.com/dcode/1a4a5c93371dfccde596
