### PR TITLE
Search for `python-config` from Python 3 as well.

### DIFF
--- a/FindPythonDev.cmake
+++ b/FindPythonDev.cmake
@@ -49,7 +49,8 @@ if (PYTHON_EXECUTABLE)
     endif ()
 else ()
     find_program(PYTHON_CONFIG
-        NAMES python-config python-config2.7 python-config2.6 python-config2.6
+        NAMES python-config python3.7-config python3.6-config python3.5-config
+              python3.4-config python-config2.7 python-config2.6 python-config2.6
               python-config2.4 python-config2.3)
 endif ()
 


### PR DESCRIPTION
Since Python under version 3.4 is now out of lifecycle and Python 3.8 not released yet, only Python 3.4-3.7 added.
