### PR TITLE
Add FindClangTidy to make the invocation of clang-tidy more generic

### DIFF
--- a/BifCl.cmake
+++ b/BifCl.cmake
@@ -35,6 +35,9 @@ macro(bif_target bifInput)
         set(BIF_OUTPUT_BRO ${CMAKE_BINARY_DIR}/scripts/base/bif/${bifInputBasename}.zeek)
         set(bro_BASE_BIF_SCRIPTS ${bro_BASE_BIF_SCRIPTS} ${BIF_OUTPUT_BRO} CACHE INTERNAL "Zeek script stubs for BIFs in base distribution of Zeek" FORCE) # Propogate to top-level
 
+        # Do this here so that all of the necessary files for each individual BIF get added to clang-tidy
+        add_clang_tidy_files(${CMAKE_CURRENT_BINARY_DIR}/${bifInputBasename}.func_def)
+
     elseif ( "${ARGV1}" STREQUAL "plugin" )
         set(plugin_name ${ARGV2})
         set(plugin_name_canon ${ARGV3})
@@ -57,6 +60,11 @@ macro(bif_target bifInput)
                                ${bifInputBasename}.register.cc)
         endif()
 
+        # Do this here so that all of the necessary files for each individual BIF get added to clang-tidy
+        foreach (bif_cc_file ${BIF_OUTPUT_CC})
+            add_clang_tidy_files(${CMAKE_CURRENT_BINARY_DIR}/${bif_cc_file})
+        endforeach(bif_cc_file)
+
         set(BIF_OUTPUT_H   ${bifInputBasename}.h)
 
         if ( NOT ZEEK_PLUGIN_BUILD_DYNAMIC )
@@ -77,6 +85,11 @@ macro(bif_target bifInput)
             ${bifInputBasename}.init.cc)
         set(BIF_OUTPUT_CC  ${bifInputBasename}.cc)
         set(BIF_OUTPUT_H   ${bifInputBasename}.h)
+
+        # Do this here so that all of the necessary files for each individual BIF get added to clang-tidy
+        foreach (bif_cc_file ${BIF_OUTPUT_CC})
+            add_clang_tidy_files(${CMAKE_CURRENT_BINARY_DIR}/${bif_cc_file})
+        endforeach(bif_cc_file)
 
         # In order be able to run Zeek from the build directory, the
         # generated Zeek script needs to be inside a directory tree

--- a/BinPAC.cmake
+++ b/BinPAC.cmake
@@ -44,6 +44,8 @@ macro(BINPAC_TARGET pacFile)
     set(pacOutputs ${BINPAC_OUTPUT_H} ${BINPAC_OUTPUT_CC})
     set_property(SOURCE ${BINPAC_OUTPUT_CC} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-tautological-compare")
 
+    add_clang_tidy_files(${CMAKE_CURRENT_BINARY_DIR}/${basename}_pac.cc)
+
     set(target "pac-${CMAKE_CURRENT_BINARY_DIR}/${pacFile}")
 
     string(REGEX REPLACE "${CMAKE_BINARY_DIR}/src/" "" target "${target}")

--- a/FindClangTidy.cmake
+++ b/FindClangTidy.cmake
@@ -1,0 +1,52 @@
+# Common functions to use clang-tidy. This requires you to have clang-tidy in your path. If you also
+# have run-clang-tidy.py in your path, it will attempt to use that to run clang-tidy in parallel.
+
+########################################################################
+# If this hasn't been initialized yet, find the program and then create a global property
+# to store the list of sources in.
+if (NOT CLANG_TIDY)
+    find_program(CLANG_TIDY NAMES clang-tidy)
+    find_program(RUN_CLANG_TIDY NAMES run-clang-tidy.py)
+
+    if (CLANG_TIDY)
+        define_property(GLOBAL PROPERTY TIDY_SRCS
+                        BRIEF_DOCS "Global list of sources for clang-tidy"
+                        FULL_DOCS "Global list of sources for clang-tidy")
+        set_property(GLOBAL PROPERTY TIDY_SRCS "")
+    endif()
+endif()
+
+########################################################################
+# Adds a list of files to the global list of files that will be checked.
+function(add_clang_tidy_files)
+    if (CLANG_TIDY)
+        foreach(f ${ARGV})
+	    if (IS_ABSOLUTE ${f})
+                set_property(GLOBAL APPEND PROPERTY TIDY_SRCS "${f}")
+            else()
+                set_property(GLOBAL APPEND PROPERTY TIDY_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
+            endif()
+        endforeach(f)
+    endif()
+endfunction()
+
+########################################################################
+# Creates the final target using the global list of files.
+function(create_clang_tidy_target)
+    if (CLANG_TIDY)
+        get_property(final_tidy_srcs GLOBAL PROPERTY TIDY_SRCS)
+        list(REMOVE_DUPLICATES final_tidy_srcs)
+
+        if (RUN_CLANG_TIDY)
+            add_custom_target(clang-tidy
+                              COMMAND ${RUN_CLANG_TIDY} -p ${CMAKE_BINARY_DIR} -clang-tidy-binary ${CLANG_TIDY} -j 4 -export-fixes ${CMAKE_BINARY_DIR}/clang-tidy.yaml ${final_tidy_srcs}
+                              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            )
+	else()
+            add_custom_target(clang-tidy
+                              COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} ${final_tidy_srcs}
+                              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            )
+        endif()
+    endif()
+endfunction()

--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -4,6 +4,7 @@
 ## ZeekPluginStatic and ZeekPluginDynamic, respectively.
 
 include(RequireCXX11)
+include(FindClangTidy)
 
 include(BifCl)
 include(BinPAC)
@@ -25,10 +26,12 @@ macro(bro_plugin_begin)
     zeek_plugin_begin(${ARGV})
 endmacro()
 
+
 # Adds *.cc files to a plugin.
 function(zeek_plugin_cc)
-        list(APPEND _plugin_objs ${ARGV})
-        set(_plugin_objs "${_plugin_objs}" PARENT_SCOPE)
+    list(APPEND _plugin_objs ${ARGV})
+    set(_plugin_objs "${_plugin_objs}" PARENT_SCOPE)
+    add_clang_tidy_files(${ARGV})
 endfunction()
 
 # This is needed to support legacy Bro plugins.

--- a/ZeekSubdir.cmake
+++ b/ZeekSubdir.cmake
@@ -11,4 +11,5 @@ function(bro_add_subdir_library name)
     endif ()
 
     set(bro_SUBDIR_LIBS "${_target}" ${bro_SUBDIR_LIBS} CACHE INTERNAL "subdir libraries")
+    add_clang_tidy_files(${ARGN})
 endfunction()


### PR DESCRIPTION
This adds some common functions to help with extending the current Zeek clang-tidy support and make it more generic.