### PR TITLE
Update FindCAF and improve FindBroker

### DIFF
--- a/FindBroker.cmake
+++ b/FindBroker.cmake
@@ -17,19 +17,41 @@
 #  BROKER_LIBRARY            The broker library
 #  BROKER_INCLUDE_DIR        The broker headers
 
-find_path(BROKER_ROOT_DIR
-    NAMES include/broker/broker.hh
-)
+if(NOT BROKER_ROOT_DIR)
+    find_path(BROKER_ROOT_DIR
+        NAMES include/broker/broker.hh
+    )
+    set(header_hints
+        "${BROKER_ROOT_DIR}/include"
+    )
+else()
+    set(header_hints
+        "${BROKER_ROOT_DIR}/include"
+        "${BROKER_ROOT_DIR}/../include"
+        "${BROKER_ROOT_DIR}/../../include"
+    )
+endif()
 
 find_library(BROKER_LIBRARY
     NAMES broker
     HINTS ${BROKER_ROOT_DIR}/lib
 )
 
-find_path(BROKER_INCLUDE_DIR
+find_path(broker_hh_dir
     NAMES broker/broker.hh
-    HINTS ${BROKER_ROOT_DIR}/include
+    HINTS ${header_hints}
 )
+
+find_path(config_hh_dir
+    NAMES broker/config.hh
+    HINTS ${header_hints}
+)
+
+if("${broker_hh_dir}" STREQUAL "${config_hh_dir}")
+    set(BROKER_INCLUDE_DIR "${broker_hh_dir}")
+else()
+    set(BROKER_INCLUDE_DIR "${broker_hh_dir}" "${config_hh_dir}")
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Broker DEFAULT_MSG

--- a/FindCAF.cmake
+++ b/FindCAF.cmake
@@ -1,8 +1,8 @@
-# Try to find CAF headers and library.
+# Try to find CAF headers and libraries.
 #
 # Use this module as follows:
 #
-#     find_package(CAF)
+#     find_package(CAF [COMPONENTS <core|io|opencl|...>*] [REQUIRED])
 #
 # Variables used by this module (they can change the default behaviour and need
 # to be set before calling find_package):
@@ -18,6 +18,10 @@
 #  CAF_LIBRARY_$C         Library file for component $C
 #  CAF_INCLUDE_DIR_$C     Include path for component $C
 
+if(CAF_FIND_COMPONENTS STREQUAL "")
+  message(FATAL_ERROR "FindCAF requires at least one COMPONENT.")
+endif()
+
 # iterate over user-defined components
 foreach (comp ${CAF_FIND_COMPONENTS})
   # we use uppercase letters only for variable names
@@ -32,7 +36,9 @@ foreach (comp ${CAF_FIND_COMPONENTS})
   if (CAF_ROOT_DIR)
     set(header_hints
         "${CAF_ROOT_DIR}/include"
-        "${CAF_ROOT_DIR}/../libcaf_${comp}")
+        "${CAF_ROOT_DIR}/libcaf_${comp}"
+        "${CAF_ROOT_DIR}/../libcaf_${comp}"
+        "${CAF_ROOT_DIR}/../../libcaf_${comp}")
   endif ()
   find_path(CAF_INCLUDE_DIR_${UPPERCOMP}
             NAMES
@@ -47,18 +53,28 @@ foreach (comp ${CAF_FIND_COMPONENTS})
   mark_as_advanced(CAF_INCLUDE_DIR_${UPPERCOMP})
   if (NOT "${CAF_INCLUDE_DIR_${UPPERCOMP}}"
       STREQUAL "CAF_INCLUDE_DIR_${UPPERCOMP}-NOTFOUND")
-    # mark as found (set back to false in case library cannot be found)
+    # mark as found (set back to false when missing library or build header)
     set(CAF_${comp}_FOUND true)
-    # add to CAF_INCLUDE_DIRS only if path isn't already set
-    set(duplicate false)
-    foreach (p ${CAF_INCLUDE_DIRS})
-      if (${p} STREQUAL ${CAF_INCLUDE_DIR_${UPPERCOMP}})
-        set(duplicate true)
-      endif ()
-    endforeach ()
-    if (NOT duplicate)
-      set(CAF_INCLUDE_DIRS ${CAF_INCLUDE_DIRS} ${CAF_INCLUDE_DIR_${UPPERCOMP}})
+    # check for CMake-generated build header for the core component
+    if ("${comp}" STREQUAL "core")
+      find_path(caf_build_header_path
+                NAMES
+                  caf/detail/build_config.hpp
+                HINTS
+                  ${header_hints}
+                  /usr/include
+                  /usr/local/include
+                  /opt/local/include
+                  /sw/include
+                  ${CMAKE_INSTALL_PREFIX}/include)
+      if ("${caf_build_header_path}" STREQUAL "caf_build_header_path-NOTFOUND")
+        message(WARNING "Found all.hpp for CAF core, but not build_config.hpp")
+        set(CAF_${comp}_FOUND false)
+      else()
+        list(APPEND CAF_INCLUDE_DIRS "${caf_build_header_path}")
+      endif()
     endif()
+    list(APPEND CAF_INCLUDE_DIRS "${CAF_INCLUDE_DIR_${UPPERCOMP}}")
     # look for (.dll|.so|.dylib) file, again giving hints for non-installed CAFs
     # skip probe_event as it is header only
     if (NOT ${comp} STREQUAL "probe_event" AND NOT ${comp} STREQUAL "test")
@@ -77,7 +93,8 @@ foreach (comp ${CAF_FIND_COMPONENTS})
                      /sw/lib
                      ${CMAKE_INSTALL_PREFIX}/lib)
       mark_as_advanced(CAF_LIBRARY_${UPPERCOMP})
-      if ("${CAF_LIBRARY_${UPPERCOMP}}" STREQUAL "CAF_LIBRARY-NOTFOUND")
+      if ("${CAF_LIBRARY_${UPPERCOMP}}"
+          STREQUAL "CAF_LIBRARY_${UPPERCOMP}-NOTFOUND")
         set(CAF_${comp}_FOUND false)
       else ()
         set(CAF_LIBRARIES ${CAF_LIBRARIES} ${CAF_LIBRARY_${UPPERCOMP}})
@@ -85,6 +102,10 @@ foreach (comp ${CAF_FIND_COMPONENTS})
     endif ()
   endif ()
 endforeach ()
+
+if (DEFINED CAF_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES CAF_INCLUDE_DIRS)
+endif()
 
 # let CMake check whether all requested components have been found
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
These changes allow users to use a build directory for `CAF_ROOT` and `BROKER_ROOT` respectively. This comes in very handy when constantly moving back-and-forth between code in CAF, Broker and Zeek.