### PR TITLE
Fix AppleClang version check, remove obsolete code

### DIFF
--- a/RequireCXX17.cmake
+++ b/RequireCXX17.cmake
@@ -13,6 +13,7 @@ include(CheckCXXSourceCompiles)
 
 set(required_gcc_version 7.0)
 set(required_clang_version 4.0)
+set(required_apple_clang_version 6.0)
 
 macro(cxx17_compile_test)
     check_cxx_source_compiles("
@@ -25,49 +26,27 @@ macro(cxx17_compile_test)
     endif ()
 endmacro()
 
-# CMAKE_CXX_COMPILER_VERSION may not always be available (e.g. particularly
-# for CMakes older than 2.8.10, but use it if it exists.
-if ( DEFINED CMAKE_CXX_COMPILER_VERSION )
-    if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
-        if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_gcc_version} )
-            message(FATAL_ERROR "GCC version must be at least "
-                    "${required_gcc_version} for C++17 support, detected: "
-                    "${CMAKE_CXX_COMPILER_VERSION}")
-        endif ()
-    elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
-        if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_clang_version} )
-            message(FATAL_ERROR "Clang version must be at least "
-                    "${required_clang_version} for C++17 support, detected: "
-                    "${CMAKE_CXX_COMPILER_VERSION}")
-        endif ()
-    endif ()
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-    cxx17_compile_test()
-
-    set(HAVE_CXX17 true)
-    return()
-endif ()
-
-# Need to manually retrieve compiler version.
 if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
-    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE
-                    gcc_version)
-    if ( ${gcc_version} VERSION_LESS ${required_gcc_version} )
+    if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_gcc_version} )
         message(FATAL_ERROR "GCC version must be at least "
-                "${required_gcc_version} for C++17 support, manually detected: "
+                "${required_gcc_version} for C++17 support, detected: "
                 "${CMAKE_CXX_COMPILER_VERSION}")
     endif ()
 elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
-    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -v ERROR_VARIABLE
-                    clang_version)
-    string(REGEX REPLACE "^clang version ([^ ]+) .*" "\\1"
-           clang_version "${clang_version}")
-    if ( ${clang_version} VERSION_LESS ${required_clang_version} )
-        message(FATAL_ERROR "GCC version must be at least "
-                "${required_clang_version} for C++17 support, manually detected: "
+    if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_clang_version} )
+        message(FATAL_ERROR "Clang version must be at least "
+                "${required_clang_version} for C++17 support, detected: "
                 "${CMAKE_CXX_COMPILER_VERSION}")
     endif ()
+elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" )
+    if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_apple_clang_version} )
+        message(FATAL_ERROR "Clang version must be at least "
+                "${required_apple_clang_version} for C++17 support, detected: "
+                "${CMAKE_CXX_COMPILER_VERSION}")
+    endif ()
+else()
+    message(FATAL_ERROR "Unrecognized compiler: ${CMAKE_CXX_COMPILER_ID} "
+            "(expected GCC or Clang)")
 endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")


### PR DESCRIPTION
As of CMake 3, we can safely assume that `CMAKE_CXX_COMPILER_VERSION` exists. Also, Apple uses different versions for its Clang version than the LLVM project. It seems like Apple Clang 6 is ≥ LLVM Clang 4.0: https://trac.macports.org/wiki/XcodeVersionInfo. With CMake 3, we can simply check this by asking for "AppleClang".

Also, the upstream projects Broker and Zeek both have a bug in their CMake setup: `cmake_minimum_required` must come *before* `project(...)` in order to get the correct policy setup: https://gitlab.kitware.com/cmake/cmake/issues/19067. I'll file separate PRs for that.