### PR TITLE
Use object libraries for subdir libs and plugins

### DIFF
--- a/ZeekPluginStatic.cmake
+++ b/ZeekPluginStatic.cmake
@@ -20,13 +20,7 @@ function(bro_plugin_link_library_static)
 endfunction()
 
 function(bro_plugin_end_static)
-    if ( bro_HAVE_OBJECT_LIBRARIES )
-        add_library(${_plugin_lib} OBJECT ${_plugin_objs})
-        set(_target "$<TARGET_OBJECTS:${_plugin_lib}>")
-    else ()
-        add_library(${_plugin_lib} STATIC ${_plugin_objs})
-        set(_target "${_plugin_lib}")
-    endif ()
+    add_library(${_plugin_lib} OBJECT ${_plugin_objs})
 
     if ( NOT "${_plugin_deps}" STREQUAL "" )
         add_dependencies(${_plugin_lib} ${_plugin_deps})
@@ -34,7 +28,8 @@ function(bro_plugin_end_static)
 
     add_dependencies(${_plugin_lib} generate_outputs)
 
-    set(bro_PLUGIN_LIBS ${bro_PLUGIN_LIBS} "${_target}" CACHE INTERNAL "plugin libraries")
+    set(bro_PLUGIN_LIBS ${bro_PLUGIN_LIBS} "$<TARGET_OBJECTS:${_plugin_lib}>" CACHE INTERNAL "plugin libraries")
+    set(bro_PLUGIN_DEPS ${bro_PLUGIN_DEPS} "${_plugin_lib}" CACHE INTERNAL "plugin dependencies")
 endfunction()
 
 macro(_plugin_target_name_static target ns name)

--- a/ZeekSubdir.cmake
+++ b/ZeekSubdir.cmake
@@ -2,14 +2,8 @@
 # Creates a target for a library of objects file in a subdirectory,
 # and adds to the global bro_SUBDIR_LIBS.
 function(bro_add_subdir_library name)
-    if ( bro_HAVE_OBJECT_LIBRARIES )
-        add_library("bro_${name}" OBJECT ${ARGN})
-        set(_target "$<TARGET_OBJECTS:bro_${name}>")
-    else ()
-        add_library("bro_${name}" STATIC ${ARGN})
-        set(_target "bro_${name}")
-    endif ()
-
-    set(bro_SUBDIR_LIBS "${_target}" ${bro_SUBDIR_LIBS} CACHE INTERNAL "subdir libraries")
+    add_library("bro_${name}" OBJECT ${ARGN})
+    set(bro_SUBDIR_LIBS "$<TARGET_OBJECTS:bro_${name}>" ${bro_SUBDIR_LIBS} CACHE INTERNAL "subdir libraries")
+    set(bro_SUBDIR_DEPS "bro_${name}" ${bro_SUBDIR_DEPS} CACHE INTERNAL "subdir dependencies")
     add_clang_tidy_files(${ARGN})
 endfunction()


### PR DESCRIPTION
With CMake 3 as build dependency, we no longer need to use the static library workaround for old CMake versions introduced via https://github.com/zeek/zeek/commit/8e7ef001b3a07cba186c8476ba044230aeb9b7aa and instead can use CMake's object libraries.

This change breaks Zeek `master` (see accompanying PR in `zeek/zeek` for the required Zeek-side changes).