### PR TITLE
InstallPackageConfigFile: replace disallowed chars in target name

### DIFF
--- a/InstallPackageConfigFile.cmake
+++ b/InstallPackageConfigFile.cmake
@@ -49,8 +49,8 @@ macro(InstallPackageConfigFile _srcfile _dstdir _dstfilename)
                           COMMENT "Installed example configuration files")
     endif ()
 
-    # '/' is invalid in target names, so replace w/ '.'
-    string(REGEX REPLACE "/" "." _flatsrc ${_srcfile})
+    # Replace characters disallowed in target names (per CMP0037) with '.'.
+    string(REGEX REPLACE "[^A-Za-z0-9_.+-]" "." _flatsrc ${_srcfile})
 
     set(_example ${_dstfile}.example)
 


### PR DESCRIPTION
InstallPackageConfigFile generates a target name from a file name,
replacing "/" with "." since "/" isn't allowed in a target name.
However, other characters that appear in file names are't allowed in
target names, notably the Windows volume separator, ":".  Address that
by replacing all characters except those explicitly allowed in a target
name according to CMP0037.

This is part of zeek/zeek#951.