### PR TITLE
Set correct OUTPUT for binary install package.

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -300,7 +300,7 @@ function(bro_plugin_end_dynamic)
 
     add_dependencies(${_plugin_lib} bro-plugin-${_plugin_name_canon})
 
-    set(_dist_tarball_name ${_plugin_name_canon}.tar.gz)
+    set(_dist_tarball_name ${_plugin_name_canon}.tgz)
     set(_dist_output ${CMAKE_CURRENT_BINARY_DIR}/${_dist_tarball_name})
 
     # Create binary install package.


### PR DESCRIPTION
The custom command for binary install packages declares an `OUTPUT`
that it produced `${plugin_name_canon}.tar.gz` in the current bin dir.
This was not correct as `zeek-plugin-create-package.sh` produces a
`tar.gz` file in the `dist` subdirectory which it symlinks into the
current bin dir as `tgz`. Due to that the output of the command was
never present and the `dist` was always run.

This patch fixes this by changing the custom command to declare that it
creates the file in the current bin directory (the `tgz` file). With
that the rule producing the file is only rerun if the inputs of the
custom command become outdated.