### PR TITLE
OpenSSLTests.cmake: check for <openssl/kdf.h>

### DIFF
--- a/OpenSSLTests.cmake
+++ b/OpenSSLTests.cmake
@@ -1,6 +1,7 @@
 include(CheckCSourceCompiles)
 include(CheckCXXSourceCompiles)
 include(CheckCSourceRuns)
+include(CheckIncludeFiles)
 
 set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
 # Use all includes, not just OpenSSL includes to see if there are
@@ -33,6 +34,8 @@ endif ()
 if (OPENSSL_VERSION VERSION_LESS "0.9.7")
     message(FATAL_ERROR "OpenSSL >= v0.9.7 required")
 endif ()
+
+check_include_files(openssl/kdf.h OPENSSL_HAVE_KDF_H)
 
 check_cxx_source_compiles("
 #include <openssl/x509.h>


### PR DESCRIPTION
This detects if `<openssl/kdf.h>` is available in the build. We use this in https://github.com/zeek/zeek/pull/1518 (transparent TLS decryption) to selectively enable TLS key derivation based on the API in this header.

@0xxon this change should be easy to land right?

EDIT: Also `check_include_file` would have been enough here as we only care about a single header, but as `check_include_files` was used in other places, I opted for this instead.