### PR TITLE
Add check for mallinfo2()

### DIFF
--- a/CheckFunctions.cmake
+++ b/CheckFunctions.cmake
@@ -2,6 +2,7 @@ include(CheckFunctionExists)
 
 check_function_exists(getopt_long HAVE_GETOPT_LONG)
 check_function_exists(mallinfo HAVE_MALLINFO)
+check_function_exists(mallinfo2 HAVE_MALLINFO2)
 check_function_exists(strcasestr HAVE_STRCASESTR)
 check_function_exists(strerror HAVE_STRERROR)
 check_function_exists(strsep HAVE_STRSEP)


### PR DESCRIPTION
glibc 2.33 deprecates mallinfo() because the returned sizes are ints. mallinfo2() upgrades these to size_ts.