### PR TITLE
new zeek_plugin_script() function to allow distribution build dependency on script changes

### DIFF
--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -19,12 +19,22 @@ function(zeek_plugin_begin ns name)
     set(_plugin_objs       "" PARENT_SCOPE)
     set(_plugin_deps       "" PARENT_SCOPE)
     set(_plugin_dist       "" PARENT_SCOPE)
+    set(_plugin_script     "" PARENT_SCOPE)
 endfunction()
 
 # This is needed to support legacy Bro plugins.
 macro(bro_plugin_begin)
     zeek_plugin_begin(${ARGV})
 endmacro()
+
+# Adds specified .zeek scripts to a plugin
+# scripts will be added to the distribution regardless of this
+# but adding them explicitly allows tracking changes in scripts
+# when building dist
+function(zeek_plugin_script)
+    list(APPEND _plugin_script ${ARGV})
+    set(_plugin_script "${_plugin_script}" PARENT_SCOPE)
+endfunction()
 
 # Adds *.cc files to a plugin.
 function(zeek_plugin_cc)

--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -19,7 +19,7 @@ function(zeek_plugin_begin ns name)
     set(_plugin_objs       "" PARENT_SCOPE)
     set(_plugin_deps       "" PARENT_SCOPE)
     set(_plugin_dist       "" PARENT_SCOPE)
-    set(_plugin_script     "" PARENT_SCOPE)
+    set(_plugin_scripts     "" PARENT_SCOPE)
 endfunction()
 
 # This is needed to support legacy Bro plugins.
@@ -31,9 +31,9 @@ endmacro()
 # scripts will be added to the distribution regardless of this
 # but adding them explicitly allows tracking changes in scripts
 # when building dist
-function(zeek_plugin_script)
-    list(APPEND _plugin_script ${ARGV})
-    set(_plugin_script "${_plugin_script}" PARENT_SCOPE)
+function(zeek_plugin_scripts)
+    list(APPEND _plugin_scripts ${ARGV})
+    set(_plugin_scripts "${_plugin_scripts}" PARENT_SCOPE)
 endfunction()
 
 # Adds *.cc files to a plugin.

--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -324,7 +324,7 @@ function(bro_plugin_end_dynamic)
     add_custom_command(OUTPUT ${_dist_output}
             COMMAND ${BRO_PLUGIN_BRO_CMAKE}/zeek-plugin-create-package.sh ${_plugin_name_canon} ${_plugin_dist}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            DEPENDS ${_plugin_lib}
+            DEPENDS ${_plugin_lib} ${_plugin_scripts}
             COMMENT "Building binary plugin package: ${_dist_tarball_name}")
 
     add_custom_target(dist ALL DEPENDS ${_dist_output})


### PR DESCRIPTION
[Zeek/Zeek Issue #1848](https://github.com/zeek/zeek/issues/1848)

Add new function zeek_plugin_script().

Script files added through this function will be added as dependencies
to the binary package, and changes to the script will be picked up
by `make && sudo make install` without a `make clean` being required.

Scripts that are *not* added through this command will still be
distributed as before, but a change to the script will require
a `make clean` ( as before ) in order to trigger repackaging if
there is no change that triggers the plugin's not script components
to build.

Follow ons to this are updating the zeek reference, adding init-plugin
support and any doc changes