### PR TITLE
Unit test support for plugins

### DIFF
--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -9,7 +9,14 @@ include(FindClangTidy)
 include(BifCl)
 include(BinPAC)
 
+# CTest support: the following does not work when called from a function. We
+# enable it always, but add tests only when zeek_plugin_begin() doesn't disable
+# testing and Zeek has unit-test support.
+enable_testing()
+
 # Begins a plugin definition, giving its namespace and name as the arguments.
+# The DISABLE_CPP_TESTS option disables unit test support. When not provided,
+# unit-testing is enabled when Zeek supports it, and disabled otherwise.
 function(zeek_plugin_begin ns name)
     _plugin_target_name(target "${ns}" "${name}")
     set(_plugin_lib        "${target}" PARENT_SCOPE)
@@ -20,6 +27,24 @@ function(zeek_plugin_begin ns name)
     set(_plugin_deps       "" PARENT_SCOPE)
     set(_plugin_dist       "" PARENT_SCOPE)
     set(_plugin_scripts    "" PARENT_SCOPE)
+
+    cmake_parse_arguments(PARSE_ARGV 2 ZEEK_PLUGIN "DISABLE_CPP_TESTS" "" "")
+
+    # Whether to build the plugin with unit-test support
+    set(_plugin_cpp_tests true PARENT_SCOPE)
+    # The set of files to check for unit tests
+    set(_plugin_cpp_test_sources "" PARENT_SCOPE)
+
+    # Cover the dynamic case (ZEEK_HAS_CPP_TESTS, based on zeek --test return
+    # code), the static one (ENABLE_ZEEK_UNIT_TESTS, provided by the build
+    # system), and a possible override if the caller opted to DISABLE_CPP_TESTS.
+    if ( (ZEEK_HAS_CPP_TESTS OR ENABLE_ZEEK_UNIT_TESTS)
+            AND NOT ZEEK_PLUGIN_DISABLE_CPP_TESTS )
+        add_definitions(-DDOCTEST_CONFIG_SUPER_FAST_ASSERTS)
+    else ()
+        set(_plugin_cpp_tests false PARENT_SCOPE)
+        add_definitions(-DDOCTEST_CONFIG_DISABLE)
+    endif()
 endfunction()
 
 # This is needed to support legacy Bro plugins.
@@ -39,7 +64,9 @@ endfunction()
 # Adds *.cc files to a plugin.
 function(zeek_plugin_cc)
     list(APPEND _plugin_objs ${ARGV})
+    list(APPEND _plugin_cpp_test_sources ${ARGV})
     set(_plugin_objs "${_plugin_objs}" PARENT_SCOPE)
+    set(_plugin_cpp_test_sources "${_plugin_cpp_test_sources}" PARENT_SCOPE)
     add_clang_tidy_files(${ARGV})
 endfunction()
 
@@ -109,6 +136,8 @@ endmacro()
 
 # Adds *.bif files to a plugin.
 macro(zeek_plugin_bif)
+    list(APPEND _plugin_cpp_test_sources ${ARGV})
+
     if ( ZEEK_PLUGIN_BUILD_DYNAMIC )
         bro_plugin_bif_dynamic(${ARGV})
     else ()
@@ -128,6 +157,29 @@ macro(zeek_plugin_end)
     else ()
         bro_plugin_end_static(${ARGV})
     endif ()
+
+    # Scan relevant files for TEST_CASE macros and generate CTest targets.
+    # This is similar to the logic in Zeek's src/CMakeLists.txt.
+    if (_plugin_cpp_tests)
+        set(test_cases "")
+        foreach (cc_file ${_plugin_cpp_test_sources})
+            file (STRINGS ${cc_file} test_case_lines REGEX "TEST_CASE")
+            foreach (line ${test_case_lines})
+                string(REGEX REPLACE "TEST_CASE\\(\"(.+)\"\\)" "\\1" test_case "${line}")
+                list(APPEND test_cases "${test_case}")
+            endforeach ()
+        endforeach ()
+        list(LENGTH test_cases num_test_cases)
+        if (${num_test_cases} GREATER 0)
+            MESSAGE(STATUS "Found ${num_test_cases} test cases for CTest")
+            foreach (test_case ${test_cases})
+                add_test(NAME "${test_case}"
+                    COMMAND zeek --test "--test-case=${test_case}")
+            endforeach()
+        endif ()
+    else ()
+        MESSAGE(STATUS "Unit-testing disabled")
+    endif ()
 endmacro()
 
 # This is needed to support legacy Bro plugins.
@@ -143,4 +195,3 @@ macro(_plugin_target_name target ns name)
         _plugin_target_name_static(${ARGV})
     endif ()
 endmacro()
-

--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -25,7 +25,7 @@ if ( NOT ZEEK_PLUGIN_INTERNAL_BUILD )
                    Zeek_SOURCE_DIR
                    ENABLE_DEBUG
                    BRO_PLUGIN_INSTALL_PATH
-                   ZEEK_EXE_PATH
+                   BRO_EXE_PATH
                    CMAKE_CXX_FLAGS
                    CMAKE_C_FLAGS
                    PCAP_INCLUDE_DIR
@@ -48,7 +48,7 @@ if ( NOT ZEEK_PLUGIN_INTERNAL_BUILD )
             CACHE INTERNAL "" FORCE)
         set(BRO_PLUGIN_BRO_BUILD "${bro_cache_Zeek_BINARY_DIR}"
             CACHE INTERNAL "" FORCE)
-        set(BRO_PLUGIN_BRO_EXE_PATH "${bro_cache_ZEEK_EXE_PATH}"
+        set(BRO_PLUGIN_BRO_EXE_PATH "${bro_cache_BRO_EXE_PATH}"
             CACHE INTERNAL "" FORCE)
 
         set(BRO_PLUGIN_BRO_CMAKE ${BRO_PLUGIN_BRO_SRC}/cmake)

--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -222,6 +222,23 @@ if ( NOT ZEEK_PLUGIN_INTERNAL_BUILD )
    message(STATUS "Zeek plugin directory: ${BRO_PLUGIN_BRO_PLUGIN_INSTALL_PATH}")
    message(STATUS "Zeek debug mode      : ${BRO_PLUGIN_ENABLE_DEBUG}")
 
+   # Determine whether Zeek has unit-test support. This would be better via an
+   # improved FindZeek, or at least an explicit feature list via zeek-config.
+   # It's unavailable if Zeek is pre-4.2 or the build got configured with
+   # --disable-cpp-tests.
+   execute_process(
+       COMMAND ${BRO_PLUGIN_BRO_EXE_PATH} --test -v
+       RESULT_VARIABLE _zeek_retcode
+       OUTPUT_QUIET ERROR_QUIET)
+
+   if ( _zeek_retcode EQUAL 0 )
+       message(STATUS "Zeek unittest support: yes")
+       set(ZEEK_HAS_CPP_TESTS true)
+   else ()
+       message(STATUS "Zeek unittest support: no")
+       set(ZEEK_HAS_CPP_TESTS false)
+   endif ()
+
    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
        # By default Darwin's linker requires all symbols to be present at link time.
        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -undefined dynamic_lookup -Wl,-bind_at_load")


### PR DESCRIPTION
This expands the zeek plugin cmake functions/macros to support CTest and unit testing via doctest.  The gist is that support for unit testing is transparently available when Zeek offers it, gets disabled when Zeek doesn't offer it, and the user can additionally opt to suppress unit test compilation despite Zeek offering it.

Part of zeek/zeek#1661.
