### PR TITLE
Escape special characters in paths before using them as regexes

### DIFF
--- a/BifCl.cmake
+++ b/BifCl.cmake
@@ -140,7 +140,11 @@ macro(bif_target bifInput)
                        COMMENT "[BIFCL] Processing ${bifInput}"
     )
 
-    string(REGEX REPLACE "${Zeek_BINARY_DIR}/src/" "" target "${target}")
+    # Make sure to escape a bunch of special characters in the path before trying to use it as a
+    # regular expression below.
+    string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" escaped_path "${Zeek_BINARY_DIR}/src/")
+
+    string(REGEX REPLACE "${escaped_path}" "" target "${target}")
     string(REGEX REPLACE "/" "-" target "${target}")
     add_custom_target(${target} DEPENDS ${BIF_OUTPUT_H} ${BIF_OUTPUT_CC})
     set_source_files_properties(${bifOutputs} PROPERTIES GENERATED 1)

--- a/BinPAC.cmake
+++ b/BinPAC.cmake
@@ -54,7 +54,11 @@ macro(BINPAC_TARGET pacFile)
 
     set(target "pac-${CMAKE_CURRENT_BINARY_DIR}/${pacFile}")
 
-    string(REGEX REPLACE "${PROJECT_BINARY_DIR}/src/" "" target "${target}")
+    # Make sure to escape a bunch of special characters in the path before trying to use it as a
+    # regular expression below.
+    string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" escaped_path "${PROJECT_BINARY_DIR}/src/")
+
+    string(REGEX REPLACE "${escaped_path}" "" target "${target}")
     string(REGEX REPLACE "/" "-" target "${target}")
     add_custom_target(${target} DEPENDS ${pacOutputs})
     set(BINPAC_BUILD_TARGET ${target})


### PR DESCRIPTION
Part of https://github.com/zeek/zeek/issues/1453. Without escaping these characters before trying to use the path as a regex, you get this error message:

```
CMake Error at cmake/BifCl.cmake:143 (string):
  string sub-command REGEX, mode REPLACE failed to compile regex
  "/Users/tim/Desktop/c++/zeek/build/src/".
Call Stack (most recent call first):
  cmake/ZeekPluginStatic.cmake:8 (bif_target)
  cmake/ZeekPluginCommon.cmake:144 (bro_plugin_bif_static)
  src/analyzer/protocol/smb/CMakeLists.txt:8 (zeek_plugin_bif)
```