### PR TITLE
Fix check for run-clang-tidy

### DIFF
--- a/FindClangTidy.cmake
+++ b/FindClangTidy.cmake
@@ -6,7 +6,11 @@
 # to store the list of sources in.
 if (NOT CLANG_TIDY)
     find_program(CLANG_TIDY NAMES clang-tidy)
-    find_program(RUN_CLANG_TIDY NAMES run-clang-tidy.py)
+    find_program(RUN_CLANG_TIDY NAMES run-clang-tidy)
+
+    if (NOT RUN_CLANG_TIDY)
+        find_program(RUN_CLANG_TIDY NAMES run-clang-tidy.py)
+    endif()
 
     if (CLANG_TIDY)
         define_property(GLOBAL PROPERTY TIDY_SRCS


### PR DESCRIPTION
This small change fixes the check for the `run-clang-tidy` script to also attempt to find the version without `.py`, which is what is provided by llvm distributions now.