### PR TITLE
Set CMP0110 to new in the plugin code to permit whitespace in test names

### DIFF
--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -158,6 +158,10 @@ macro(zeek_plugin_end)
         bro_plugin_end_static(${ARGV})
     endif ()
 
+    if ( POLICY CMP0110 )
+        cmake_policy(SET CMP0110 NEW)
+    endif ()
+
     # Scan relevant files for TEST_CASE macros and generate CTest targets.
     # This is similar to the logic in Zeek's src/CMakeLists.txt.
     if (_plugin_cpp_tests)


### PR DESCRIPTION
This took me a bit to figure out: since `zeek_plugin_end` is a macro, setting the policy in `ZeekPluginCommon.cmake` only takes effect when done inside the macro, not higher up in the file. Two related things to flag:

- Should we additionally wrap the policy adjustment in its own `cmake_policy(PUSH)` / `cmake_policy(POP)`?
- Reading up about cmake policies, it seems like the preferred way to set them (if you need to set them at all) is at the project toplevel, but this is a plugin setting, so this code will also run for external plugins, Zeek packages with plugins, etc. It seems okay to me to set this policy for all users, but one could also argue that we're not in charge of the policies of any Zeek plugin out there.

@Neverlord let me know in case this clashes with any cmake cleanups you're planning!

Resolves #46.