### PR TITLE
Set DONT_HAVE_LIBPCAP_DLT_LINUX_SLL2 if libpcap doesn't have LINUX_SLL2 support

### DIFF
--- a/PCAPTests.cmake
+++ b/PCAPTests.cmake
@@ -79,5 +79,11 @@ if (NOT HAVE_DLT_NFLOG)
     set(DLT_NFLOG 239)
 endif ()
 
+check_symbol_exists(DLT_LINUX_SLL2 pcap.h HAVE_DLT_LINUX_SLL2)
+if (NOT HAVE_DLT_LINUX_SLL2)
+    set(DONT_HAVE_LIBPCAP_DLT_LINUX_SLL2 true)
+    message(STATUS "No DLT_LINUX_SLL2 support in libpcap")
+endif ()
+
 set(CMAKE_REQUIRED_INCLUDES)
 set(CMAKE_REQUIRED_LIBRARIES)


### PR DESCRIPTION
`DLT_LINUX_SLL` and `DLT_LINUX_SLL2` are libpcap link-types for fake link-layer headers used when capturing packets on Linux with `PF_PACKET` (which happens if you run `tcpdump -i any`).

The difference between the versions is a slightly modified header/struct and link-type number. Zeek currently understands version 1. I'm working on https://github.com/zeek/zeek/pull/2340 which adds support for reading version 2 PCAP files.

Libpcap only added `DLT_LINUX_SLL2` support in version 1.10.0. 

On @timwoj's suggestion, this PR has `DONT_HAVE_LIBPCAP_DLT_LINUX_SLL2` set by cmake allows for conditionally compiling in a check/abort when trying to read this type of file with an older libpcap (i.e., Ubuntu <= 18, Debian <= 10, Centos <= 7). The `btest` case added in https://github.com/zeek/zeek/pull/2340 also tests for `DONT_HAVE_LIBPCAP_DLT_LINUX_SLL2` in `zeek-config.h` and skips the test on those platforms.