### PR TITLE
BinPAC: Allow external builtin-plugins to find .pac files from Zeek's tree

### DIFF
--- a/BinPAC.cmake
+++ b/BinPAC.cmake
@@ -15,6 +15,10 @@ macro(BINPAC_TARGET pacFile)
         endif ()
 
         set(binpacDep "${BinPAC_EXE}")
+
+        # Ensure that for plugins included via --include-plugins, the Zeek's
+        # source tree paths are added to binpac's include path as well.
+        set(BinPAC_addl_args "-I;${CMAKE_SOURCE_DIR};-I;${CMAKE_SOURCE_DIR}/src")
     else ()
         if ( BRO_PLUGIN_BRO_BUILD )
             # Zeek 3.2+ has auxil/ instead of aux/

--- a/BroPlugin.cmake
+++ b/BroPlugin.cmake
@@ -1,1 +1,1 @@
-include(ZeekPlugin.cmake)
+include(ZeekPlugin)


### PR DESCRIPTION
When including icsnpp-bacnet via --include-plugins, binpac failed to compile the bacnet.pac file as it didn't find the zeek/binpac.pac due to Zeek's src path not being included.

With this change, external builtin-plugins have -I flags added for their binpac invocation.