### PR TITLE
Plugins: Modification for included plugins

### DIFF
--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -28,6 +28,8 @@ function(zeek_plugin_begin ns name)
     set(_plugin_dist       "" PARENT_SCOPE)
     set(_plugin_scripts    "" PARENT_SCOPE)
 
+    include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR})
+
     cmake_parse_arguments(PARSE_ARGV 2 ZEEK_PLUGIN "DISABLE_CPP_TESTS" "" "")
 
     # Whether to build the plugin with unit-test support

--- a/ZeekPluginStatic.cmake
+++ b/ZeekPluginStatic.cmake
@@ -15,7 +15,7 @@ endfunction()
 
 function(bro_plugin_link_library_static)
     foreach ( lib ${ARGV} )
-        set(bro_SUBDIR_LIBS ${bro_SUBDIR_LIBS} "${lib}" CACHE INTERNAL "plugin libraries")
+        set(bro_PLUGIN_LINK_LIBS ${bro_PLUGIN_LINK_LIBS} "${lib}" CACHE INTERNAL "plugin link libraries")
     endforeach ()
 endfunction()
 


### PR DESCRIPTION
* Track libraries to link in new `bro_PLUGIN_LINK_LIBS` variable
* Unconditionally use include_directories for source/binary dir in `zeek_plugin_begin()`

Relates to zeek/zeek#2482 zeek/zeek#2520