### PR TITLE
zeek-plugin-create-package: Dereference symbolic links during cp

### DIFF
--- a/zeek-plugin-create-package.sh
+++ b/zeek-plugin-create-package.sh
@@ -19,7 +19,7 @@ DIST=dist/${name}
 mkdir -p "${DIST}"
 
 # Copy files to be distributed to temporary location.
-cp -r __bro_plugin__ lib scripts "${DIST}"
+cp -rL __bro_plugin__ lib scripts "${DIST}"
 for i in ${addl}; do
     if [ -e "../$i" ]; then
         dir=$(dirname "$i")


### PR DESCRIPTION
During #61, the symbolic link dereferencing that was done when creating the manifest was disregarded. The current version packages up symlinks to directories.

Found by @dopheide-esnet, thanks!