### PR TITLE
BinPAC: Ensure zeek/src/include is added to BinPAC include path

### DIFF
--- a/BinPAC.cmake
+++ b/BinPAC.cmake
@@ -18,7 +18,7 @@ macro(BINPAC_TARGET pacFile)
 
         # Ensure that for plugins included via --include-plugins, the Zeek's
         # source tree paths are added to binpac's include path as well.
-        set(BinPAC_addl_args "-I;${CMAKE_SOURCE_DIR};-I;${CMAKE_SOURCE_DIR}/src")
+        set(BinPAC_addl_args "-I;${CMAKE_SOURCE_DIR};-I;${CMAKE_SOURCE_DIR}/src;-I;${CMAKE_SOURCE_DIR}/src/include")
     else ()
         if ( BRO_PLUGIN_BRO_BUILD )
             # Zeek 3.2+ has auxil/ instead of aux/


### PR DESCRIPTION
We've removed the zeek -> . symlink from zeek/src and now create
it dynamically during the build in zeek/src/include. Ensure that
new directory is in BinPAC's include path, too.

Fixes --include-plugins with plugins that contain BinPAC based analyzers
and using `%include zeek/binpac.pac` as, for example, this one:

     https://github.com/cisagov/icsnpp-bacnet.git