### PR TITLE
Disable LSAN when running spicyz during analyzer build.

### DIFF
--- a/BuiltInSpicyAnalyzer.cmake
+++ b/BuiltInSpicyAnalyzer.cmake
@@ -38,8 +38,9 @@ function (spicy_add_analyzer)
             COMMENT "Compiling ${SPICY_ANALYZER_NAME} analyzer"
             COMMAND
                 ${CMAKE_COMMAND} -E env
-                "ZEEK_SPICY_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/scripts/spicy" $<TARGET_FILE:spicyz>
-                -L ${spicy_SOURCE_DIR}/hilti/lib -L ${spicy_SOURCE_DIR}/spicy/lib -x
+                "ZEEK_SPICY_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/scripts/spicy"
+                ASAN_OPTIONS=$ENV{ASAN_OPTIONS}:detect_leaks=0 $<TARGET_FILE:spicyz> -L
+                ${spicy_SOURCE_DIR}/hilti/lib -L ${spicy_SOURCE_DIR}/spicy/lib -x
                 ${CMAKE_CURRENT_BINARY_DIR}/${NAME_LOWER} ${SPICYZ_FLAGS} ${SPICY_ANALYZER_SOURCES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/ZeekSpicyAnalyzerSupport.cmake
+++ b/ZeekSpicyAnalyzerSupport.cmake
@@ -58,7 +58,8 @@ function (spicy_add_analyzer)
         OUTPUT ${OUTPUT}
         DEPENDS ${SPICY_ANALYZER_SOURCES} spicyz
         COMMENT "Compiling ${SPICY_ANALYZER_NAME} analyzer"
-        COMMAND spicyz -o ${OUTPUT} ${_SPICYZ_FLAGS} ${SPICY_ANALYZER_SOURCES} ${CXX_LINK}
+        COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=$ENV{ASAN_OPTIONS}:detect_leaks=0 spicyz -o
+                ${OUTPUT} ${_SPICYZ_FLAGS} ${SPICY_ANALYZER_SOURCES} ${CXX_LINK}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_custom_target(${SPICY_ANALYZER_NAME} ALL DEPENDS ${OUTPUT}


### PR DESCRIPTION
This patch disables LSAN for invocations of `spicyz` when building builtin or external Spicy analyzers. ASAN automatically enables LSAN, even on platforms where it is unsupported (e.g., macOS), so we disable it again for this use case.

Closes zeek/zeek#3026.