### PR TITLE
ZeekPluginDynamic: Add back newline in magic file

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -112,7 +112,7 @@ function (zeek_add_dynamic_plugin ns name)
 
     # Write the 'magic' __bro_plugin__ file. We can do that once during CMake
     # invocation since it won't change.
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/__bro_plugin__" "${full_name}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/__bro_plugin__" "${full_name}\n")
 
     # Stop here unless building 3rd party plugins.
     if (ZEEK_PLUGIN_INTERNAL_BUILD)


### PR DESCRIPTION
zkg's tests failed with current master due to the newline not being in the magic plugin file anymore.

Keep it for consistency so we don't need to play tricks to normalize the baselines across versions.