### PR TITLE
Ensure that dist files are included in plugin tarballs

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -135,7 +135,7 @@ function (zeek_add_dynamic_plugin ns name)
     add_custom_command(
         OUTPUT ${dist_tarball_path}
         COMMAND ${ZEEK_PLUGIN_SCRIPTS_PATH}/zeek-plugin-create-package.sh ${canon_name}
-                ${DIST_FILES}
+                ${FN_ARGS_DIST_FILES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${target_name}
         # DEPENDS ${target_name} ${_plugin_scripts}


### PR DESCRIPTION
`DIST_FILES` isn't set when we add the custom command. Use the variable from the call to `cmake_parse_arguments` instead.

Fixes https://github.com/zeek/zeek/issues/3107

From a simple test plugin generated by `init-plugin` with no other changes:

```
tim@coregeek2 build% tar -tzf dist/Test_TestPlugin-0.1.0.tar.gz                                      [master]
Test_TestPlugin/
Test_TestPlugin/__bro_plugin__
Test_TestPlugin/CHANGES
Test_TestPlugin/README
Test_TestPlugin/VERSION
Test_TestPlugin/scripts/
Test_TestPlugin/lib/
Test_TestPlugin/lib/bif/
Test_TestPlugin/lib/Test-TestPlugin.darwin-arm64.so
Test_TestPlugin/lib/bif/testplugin.bif.zeek
Test_TestPlugin/lib/bif/__load__.zeek
Test_TestPlugin/scripts/Test/
Test_TestPlugin/scripts/__load__.zeek
Test_TestPlugin/scripts/__preload__.zeek
Test_TestPlugin/scripts/types.zeek
Test_TestPlugin/scripts/Test/TestPlugin/
Test_TestPlugin/scripts/Test/TestPlugin/__load__.zeek
```