### PR TITLE
ZeekPlugin: Add SCRIPT_FILES argument

### DIFF
--- a/ZeekPlugin.cmake
+++ b/ZeekPlugin.cmake
@@ -159,6 +159,7 @@ endmacro ()
 #   [INCLUDE_DIRS ...]
 #   [DEPENDENCIES ...]
 #   [DIST_FILES ...]
+#   [SCRIPT_FILES ...]
 #   [SOURCES ...]
 #   [BIFS ...]
 #   [[PAC ...] ... ]
@@ -171,6 +172,11 @@ endmacro ()
 # * DIST_FILES:
 #   Adds additional files to install alongside the plugin when building a
 #   dynamic plugin. Ignored when building static plugins.
+# * SCRIPT_FILES:
+#   Marks the given script files as dependencies for the tarball when building
+#   a dynamic plugin. This is currently for dependency tracking only - the
+#   plugin's whole script directory is included in the resulting tarball
+#   regardless of the files provided here. Ignored when building static plugins.
 # * SOURCES:
 #   List of C++ files for compiling the plugin.
 # * BIFS:

--- a/ZeekPluginCommon.cmake
+++ b/ZeekPluginCommon.cmake
@@ -73,6 +73,8 @@ macro (zeek_plugin_end)
         ${_plugin_bif_files}
         DIST_FILES
         ${_plugin_dist}
+        SCRIPT_FILES
+        ${_plugin_scripts}
         ${_plugin_pac_args})
 
     if (POLICY CMP0110)

--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -37,8 +37,15 @@ function (zeek_add_dynamic_plugin ns name)
         ${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${lib_dir}" PREFIX ""
                                   LIBRARY_OUTPUT_NAME "${ns}-${name}.${HOST_ARCHITECTURE}")
 
-    # Parse arguments (note: DIST_FILES are ignored in static builds).
-    set(fn_varargs INCLUDE_DIRS DEPENDENCIES SOURCES BIFS DIST_FILES PAC)
+    # Parse arguments (note: DIST_FILES and SCRIPT_FILES are ignored in static builds).
+    set(fn_varargs
+        INCLUDE_DIRS
+        DEPENDENCIES
+        SOURCES
+        BIFS
+        DIST_FILES
+        SCRIPT_FILES
+        PAC)
     cmake_parse_arguments(FN_ARGS "" "" "${fn_varargs}" ${ARGN})
 
     # Take care of compiling BIFs.
@@ -137,8 +144,7 @@ function (zeek_add_dynamic_plugin ns name)
         COMMAND ${ZEEK_PLUGIN_SCRIPTS_PATH}/zeek-plugin-create-package.sh ${canon_name}
                 ${DIST_FILES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS ${target_name}
-        # DEPENDS ${target_name} ${_plugin_scripts}
+        DEPENDS ${target_name} ${FN_ARGS_SCRIPT_FILES}
         COMMENT "Building binary plugin package: ${dist_tarball_path}")
     add_custom_target(${target_name}_tarball ALL DEPENDS ${dist_tarball_path})
 

--- a/ZeekPluginStatic.cmake
+++ b/ZeekPluginStatic.cmake
@@ -28,7 +28,7 @@ function (zeek_add_static_plugin ns name)
         target_compile_definitions(${target_name} PRIVATE ZEEK_CONFIG_SKIP_VERSION_H)
     endif ()
 
-    # Parse arguments (note: DIST_FILES are ignored in static builds).
+    # Parse arguments (note: DIST_FILES and SCRIPT_FILES are ignored in static builds).
     set(fn_varargs INCLUDE_DIRS DEPENDENCIES SOURCES BIFS DIST_FILES PAC)
     cmake_parse_arguments(FN_ARGS "" "" "${fn_varargs}" ${ARGN})
 


### PR DESCRIPTION
This adds the old zeek_plugin_scripts() mechanism to the new zeek_add_plugin() function such that upon modification of the listed script files the tarball is re-created.

Closes #75