### PR TITLE
ZeekPlugin: Use ZEEK_CMAKE_BUILD_TYPE if CMAKE_BUILD_TYPE is not set

### DIFF
--- a/ZeekPlugin.cmake
+++ b/ZeekPlugin.cmake
@@ -54,6 +54,10 @@ function (zeek_plugin_bootstrapping)
     # Another historic quirk: force CMAKE_EXPORT_COMPILE_COMMANDS to ON.
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON
         CACHE PATH "Configures whether to write a compile database." FORCE)
+
+    # When CMAKE_BUILD_TYPE is not set, use the one from Zeek.
+    set(CMAKE_BUILD_TYPE "${ZEEK_CMAKE_BUILD_TYPE}"
+        CACHE STRING "Configures the CMAKE_BUILD_TYPE for the plugin.")
 endfunction ()
 
 # Make sure BifCl and BinPAC are available.


### PR DESCRIPTION
Existing ./configure scripts of external plugins have logic to switch a plugin's CMAKE_BUILD_TYPE to Debug if `zeek-config --build-type` yields "debug". Otherwise, CMAKE_BUILD_TYPE was previously set as RelWithDebInfo. After the CMake rework for 6.0 this logic got lost and a plugin's CMAKE_BUILD_TYPE is always empty. This results in builds without optimizations and/or debug symbols disregarding Zeek's configuration which is not intuitive behavior.

Instead of resurrecting above zeek-config mechanism, encode Zeek's CMAKE_BUILD_TYPE in ZeekPluginBootstrap.cmake and set it during plugin bootstrapping.

This restores plugins compiled against a Zeek Debug build having CMAKE_BUILD_TYPE Debug and over-corrects a bit in that CMAKE_BUILD_TYPE Release is now used for plugins when building against Zeek with build type is Release.

This change does not attempt to propagate any custom CXXFLAGS or LDFLAGS to a Zeek plugin: We are not doing this with Zeek 5.2 either. This is to fix the regression only.

Relates to zeek/zeek#3090.