### PR TITLE
ZeekPlugin: Fixup CMAKE_BUILD_TYPE setting

### DIFF
--- a/ZeekPlugin.cmake
+++ b/ZeekPlugin.cmake
@@ -56,8 +56,11 @@ function (zeek_plugin_bootstrapping)
         CACHE PATH "Configures whether to write a compile database." FORCE)
 
     # When CMAKE_BUILD_TYPE is not set, use the one from Zeek.
-    set(CMAKE_BUILD_TYPE "${ZEEK_CMAKE_BUILD_TYPE}"
-        CACHE STRING "Configures the CMAKE_BUILD_TYPE for the plugin.")
+    if (NOT CMAKE_BUILD_TYPE)
+        message(STATUS "Setting plugin CMAKE_BUILD_TYPE to ${ZEEK_CMAKE_BUILD_TYPE}")
+        set(CMAKE_BUILD_TYPE "${ZEEK_CMAKE_BUILD_TYPE}"
+            CACHE STRING "Configures the CMAKE_BUILD_TYPE for the plugin." FORCE)
+    endif ()
 endfunction ()
 
 # Make sure BifCl and BinPAC are available.


### PR DESCRIPTION
set() for CMAKE_BUILD_TYPE has no effect without force even if empty, do a conditional set(...FORCE) instead.