### PR TITLE
Prefer to find `spicy-config` in configured over default search paths.

### DIFF
--- a/FindSpicy.cmake
+++ b/FindSpicy.cmake
@@ -40,6 +40,7 @@ macro (configure)
             message(STATUS "'${SPICY_CONFIG}' does not exist")
         endif ()
     else ()
+        # Attempt to find `spicy-config` only with configured paths.
         find_program(
             spicy_config spicy-config
             HINTS ${SPICY_ROOT_DIR}/bin
@@ -47,7 +48,13 @@ macro (configure)
                   $ENV{SPICY_ROOT_DIR}/bin
                   $ENV{SPICY_ROOT_DIR}/build/bin
                   # Try build directory of Spicy distribution we may be part of.
-                  ${PROJECT_SOURCE_DIR}/../../build/bin)
+                  ${PROJECT_SOURCE_DIR}/../../build/bin
+            NO_DEFAULT_PATH)
+
+        # If above search was not successful attempt to find the program in
+        # builtin search paths. CMake's `find_program` will only execute a new
+        # search if the output variable `spicy-config` is unset.
+        find_program(spicy_config spicy-config)
     endif ()
 
     if (NOT spicy_config)


### PR DESCRIPTION
When searching for `spicy-config` we previously we would pass configured paths as `HINTS` to `find_program`. Since `HINTS` adds additional search paths to builtin search paths, this did not find the correct `spicy-config` if Zeek was configured with `--with-spicy=<SPICY_PREFIX>` and another `spicy-config` was found in builtin paths; instead we would always prefer to use the one from builtin paths.

With this patch we split the search for `spicy-config` into two phases, one using exclusively the configured paths and only if that search did not succeed a second phase which would look in builtin paths. With that we prefer a `spicy-config` from an explicitly configured path.