### PR TITLE
use -R for macos compatibility

### DIFF
--- a/zeek-plugin-create-package.sh
+++ b/zeek-plugin-create-package.sh
@@ -19,7 +19,7 @@ DIST=dist/${name}
 mkdir -p "${DIST}"
 
 # Copy files to be distributed to temporary location.
-cp -rL __bro_plugin__ lib scripts "${DIST}"
+cp -RL __bro_plugin__ lib scripts "${DIST}"
 for i in ${addl}; do
     if [ -e "../$i" ]; then
         dir=$(dirname "$i")


### PR DESCRIPTION
Doing `./configure && make && make install` on a plugin throws the following errors on macos:

```
$ ./configure && make && make install
...
make: [build-it] Error 1 (ignored)
( cd build && make )
...
[100%] Building binary plugin package: /Users/yacin.nadji/src/VantageTime/build/Corelight_VantageTime.tgz
cp: the -H, -L, and -P options may not be specified with the -r option.
[100%] Built target Corelight_VantageTime_tarball
```

This results in a largely empty plugin tarball to be installed. Digging into this further, we see it's from:

```
$ bash -x /Users/yacin.nadji/zeek/share/zeek/cmake/zeek-plugin-create-package.sh Corelight_VantageTime
+ '[' 1 = 0 ']'
+ name=Corelight_VantageTime
+ shift
+ addl=
+ DIST=dist/Corelight_VantageTime
+ mkdir -p dist/Corelight_VantageTime
+ cp -rL __bro_plugin__ lib scripts dist/Corelight_VantageTime
cp: the -H, -L, and -P options may not be specified with the -r option.
++ test -e ../VERSION
++ head -1 ../VERSION
+ tgz=Corelight_VantageTime-0.1.0.tar.gz
+ rm -f Corelight_VantageTime.tgz Corelight_VantageTime-0.1.0.tar.gz
+ tar czf dist/Corelight_VantageTime-0.1.0.tar.gz -C dist Corelight_VantageTime
+ rm -rf dist/Corelight_VantageTime
+ ln -s dist/Corelight_VantageTime-0.1.0.tar.gz Corelight_VantageTime.tgz
```

Everything seems to work with `-R`. See a similar fix in [ntopng](https://github.com/ntop/ntopng/issues/1285).