### PR TITLE
OpenSSLTests: Remove krb5.h include test

### DIFF
--- a/OpenSSLTests.cmake
+++ b/OpenSSLTests.cmake
@@ -22,21 +22,7 @@ check_c_source_compiles(
     including_ssl_h_works)
 
 if (NOT including_ssl_h_works)
-    # On Red Hat we may need to include Kerberos header.
-    set(CMAKE_REQUIRED_INCLUDES ${includes} /usr/kerberos/include)
-    check_c_source_compiles(
-        "
-        #include <krb5.h>
-        #include <openssl/ssl.h>
-        int main() { return 0; }
-    "
-        NEED_KRB5_H)
-    if (NOT NEED_KRB5_H)
-        message(FATAL_ERROR "OpenSSL test failure.  See CmakeError.log for details.")
-    else ()
-        message(STATUS "OpenSSL requires Kerberos header")
-        include_directories("/usr/kerberos/include")
-    endif ()
+    message(FATAL_ERROR "OpenSSL test failure.  See CmakeError.log for details.")
 endif ()
 
 if (OPENSSL_VERSION VERSION_LESS "0.9.7")


### PR DESCRIPTION
The only place NEED_KRB5_H was referenced on the Zeek side didn't seem to have any effect and so it was dropped. Remove the check and extra logic for /usr/kerberos/include assuming the Red Hat distro mentioned in the comment is long out of support.