### PR TITLE
Allow injecting env vars into `spicyz` invocation in `spicy_add_analyzers`

### DIFF
--- a/ZeekSpicyAnalyzerSupport.cmake
+++ b/ZeekSpicyAnalyzerSupport.cmake
@@ -16,11 +16,12 @@ include(GNUInstallDirs)
 #         [PACKAGE_NAME <package_name>]
 #         [SCRIPTS <additional script files to install>...]
 #         [CXX_LINK <libraries to link>...]
+#         [ENV <environment variable=value>...]
 #     )
 function (spicy_add_analyzer)
     set(options)
     set(oneValueArgs NAME PACKAGE_NAME)
-    set(multiValueArgs SOURCES SCRIPTS CXX_LINK)
+    set(multiValueArgs ENV SOURCES SCRIPTS CXX_LINK)
 
     cmake_parse_arguments(PARSE_ARGV 0 SPICY_ANALYZER "${options}" "${oneValueArgs}"
                           "${multiValueArgs}")
@@ -58,8 +59,10 @@ function (spicy_add_analyzer)
         OUTPUT ${OUTPUT}
         DEPENDS ${SPICY_ANALYZER_SOURCES} spicyz
         COMMENT "Compiling ${SPICY_ANALYZER_NAME} analyzer"
-        COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=$ENV{ASAN_OPTIONS}:detect_leaks=0 spicyz -o
-                ${OUTPUT} ${_SPICYZ_FLAGS} ${SPICY_ANALYZER_SOURCES} ${CXX_LINK}
+        COMMAND
+            ${CMAKE_COMMAND} -E env ASAN_OPTIONS=$ENV{ASAN_OPTIONS}:detect_leaks=0
+            ${SPICY_ANALYZER_ENV} spicyz -o ${OUTPUT} ${_SPICYZ_FLAGS} ${SPICY_ANALYZER_SOURCES}
+            ${CXX_LINK}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_custom_target(${SPICY_ANALYZER_NAME} ALL DEPENDS ${OUTPUT}


### PR DESCRIPTION
This adds a named arg `ENV` to `spicy_add_analyzer` which accepts values `VAR=VAL` which get injected into the generated `spicyz` invocation. This makes it possible to e.g., parameterize values like `HILTI_CXX_INCLUDE_DIRS`.