### PR TITLE
Remove overly cautious caching

### DIFF
--- a/ZeekPlugin.cmake
+++ b/ZeekPlugin.cmake
@@ -6,7 +6,7 @@ function (zeek_plugin_bootstrapping)
     # Plugins that build against the source tree set ZEEK_DIST. Here, we have our
     # package file plus ZeekPluginConfig.cmake to help out.
     if (ZEEK_DIST)
-        message("USING ZEEK_DIST: ${ZEEK_DIST}")
+        message("-- Using ZEEK_DIST: ${ZEEK_DIST}")
         find_package(Zeek REQUIRED CONFIG NO_DEFAULT_PATH PATHS "${ZEEK_DIST}/build")
         return()
     endif ()
@@ -64,10 +64,8 @@ function (zeek_plugin_bootstrapping)
 endfunction ()
 
 # Make sure BifCl and BinPAC are available.
-if (NOT ZEEK_PLUGIN_INTERNAL_BUILD AND NOT ZEEK_PLUGIN_HAD_BOOTSTRAPPING)
+if (NOT ZEEK_PLUGIN_INTERNAL_BUILD)
     zeek_plugin_bootstrapping()
-    # Remember that we have called the function to not call it again.
-    set(ZEEK_PLUGIN_HAD_BOOTSTRAPPING ON CACHE BOOL "Plugin bootstrapping has completed." FORCE)
 endif ()
 
 include(BifCl)


### PR DESCRIPTION
I think I tried to protect against `ZEEK_DIST` not being a cache variable and to avoid FORCE-setting a bunch of cache variables each run. The latter would mean user-made changes to the cache file are overridden each time. However, after going through the function, I think touching any of those variables is a bad idea anyways. So we can just not do the caching.

Worked locally for me (forcing CMake to re-run by touching the CMakeLists.txt file in a plugin). But any more testing is most welcome.

Closes #76.