### PR TITLE
zeek_add_plugin: Fix INCLUDE_DIRS

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -81,6 +81,11 @@ function (zeek_add_dynamic_plugin ns name)
         zeek_next_pac_block(at_end pacInputs pacRemainder ${pacRemainder})
     endwhile ()
 
+    # Add user-defined extra include directories.
+    if (FN_ARGS_INCLUDE_DIRS)
+        target_include_directories(${target_name} PRIVATE ${FN_ARGS_INCLUDE_DIRS})
+    endif ()
+
     # Add user-defined extra dependencies.
     if (FN_ARGS_DEPENDENCIES)
         target_link_libraries(${target_name} PUBLIC ${FN_ARGS_DEPENDENCIES})

--- a/ZeekPluginStatic.cmake
+++ b/ZeekPluginStatic.cmake
@@ -63,6 +63,11 @@ function (zeek_add_static_plugin ns name)
         target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     endif ()
 
+    # Add user-defined extra include directories.
+    if (FN_ARGS_INCLUDE_DIRS)
+        target_include_directories(${target_name} PRIVATE ${FN_ARGS_INCLUDE_DIRS})
+    endif ()
+
     # Add extra dependencies.
     if (FN_ARGS_DEPENDENCIES)
         target_link_libraries(${target_name} PUBLIC ${FN_ARGS_DEPENDENCIES})


### PR DESCRIPTION
INCLUDE_DIRS is allowed for zeek_add_plugin(), but it has not been threaded through to the target.

Relates to zeek/zeek#3420.