### PR TITLE
spicy_add_analyzer: Depend on CXX_LINK arg

### DIFF
--- a/ZeekSpicyAnalyzerSupport.cmake
+++ b/ZeekSpicyAnalyzerSupport.cmake
@@ -57,7 +57,7 @@ function (spicy_add_analyzer)
 
     add_custom_command(
         OUTPUT ${OUTPUT}
-        DEPENDS ${SPICY_ANALYZER_SOURCES} spicyz
+        DEPENDS ${SPICY_ANALYZER_SOURCES} spicyz ${SPICY_ANALYZER_CXX_LINK}
         COMMENT "Compiling ${SPICY_ANALYZER_NAME} analyzer"
         COMMAND
             ${CMAKE_COMMAND} -E env ASAN_OPTIONS=$ENV{ASAN_OPTIONS}:detect_leaks=0


### PR DESCRIPTION
In the spicy-quic project it was found that the quic.hlto wasn't being rebuilt/relinked when the libdecrypt_crypto.a library changed. @bbannier hinted at a missing dependency on the CXX_LINK argument for the custom command invoking spicyz.