### PR TITLE
FindZeek: Split --include_dirs on colon instead of space

### DIFF
--- a/FindZeek.cmake
+++ b/FindZeek.cmake
@@ -107,7 +107,7 @@ else ()
     run_zeek_config(ZEEK_VERSION "--version")
     run_zeek_config(ZEEK_BUILD_TYPE "--build_type")
 
-    string(REPLACE " " ";" ZEEK_INCLUDE_DIRS "${ZEEK_INCLUDE_DIRS}")
+    string(REPLACE ":" ";" ZEEK_INCLUDE_DIRS "${ZEEK_INCLUDE_DIRS}")
 
     # Copied from Zeek to generate numeric version number.
     string(REGEX REPLACE "[.-]" " " version_numbers "${ZEEK_VERSION}")


### PR DESCRIPTION
The zeek-config output is colon separated. Using ZEEK_INCLUDE_DIRS for include_directories() previously did not work correctly as ZEEK_INCLUDE_DIRS was treated as a single directory resulting in:

    -I/opt/zeek/include:/usr/include