### PR TITLE
configuration hooks to enable gen-zam to take multiple arguments

### DIFF
--- a/Gen-ZAM.cmake
+++ b/Gen-ZAM.cmake
@@ -3,10 +3,10 @@
 # GEN_ZAM_OUTPUT_H.
 #
 # The macro also creates a target that can be used to define depencencies on the
-# generated files. The name of the target includes the input template filename
+# generated files. The name of the target includes the input template directory
 # to make it unique, and is added automatically to bro_ALL_GENERATED_OUTPUTS.
-macro (gen_zam_target gzInput)
-    get_filename_component(gzInputBasename "${gzInput}" NAME)
+macro (gen_zam_target gzInputDir)
+    get_filename_component(gzInputBasename "${gzInputDir}" NAME)
 
     set(target "gen-zam-${gzInputBasename}")
     string(REGEX REPLACE "/" "-" target "${target}")
@@ -41,8 +41,8 @@ macro (gen_zam_target gzInput)
 
     add_custom_command(
         OUTPUT ${GEN_ZAM_OUTPUT_H}
-        COMMAND ${GEN_ZAM_EXE} ARGS ${gzInput}
-        DEPENDS ${gzInput} ${GEN_ZAM_EXE}
+        COMMAND ${GEN_ZAM_EXE} ARGS ${GEN_ZAM_SRC}
+        DEPENDS ${GEN_ZAM_SRC} ${GEN_ZAM_EXE}
         COMMENT "[gen-zam] Generating ZAM operations"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
This PR is a companion to one I'm about to put in for Zeek to enable `gen-zam` to take multiple arguments. The Zeek PR doesn't actually leverage this capability yet (but I'll start working on a branch that does once https://github.com/zeek/gen-zam/pull/13 is merged).