### PR TITLE
Support pointing `BROKER_ROOT_DIR` at Zeek build tree

### DIFF
--- a/FindBroker.cmake
+++ b/FindBroker.cmake
@@ -21,8 +21,10 @@ if (NOT BROKER_ROOT_DIR)
     find_path(BROKER_ROOT_DIR NAMES include/broker/broker.hh)
     set(header_hints "${BROKER_ROOT_DIR}/include")
 else ()
-    set(header_hints "${BROKER_ROOT_DIR}/include" "${BROKER_ROOT_DIR}/../include"
-                     "${BROKER_ROOT_DIR}/../../include")
+    set(header_hints
+        "${BROKER_ROOT_DIR}/include" "${BROKER_ROOT_DIR}/../include"
+        "${BROKER_ROOT_DIR}/../../include" "${BROKER_ROOT_DIR}/libbroker"
+        "${BROKER_ROOT_DIR}/../libbroker" "${BROKER_ROOT_DIR}/../../libbroker")
 endif ()
 
 find_library(BROKER_LIBRARY NAMES broker HINTS ${BROKER_ROOT_DIR}/lib)


### PR DESCRIPTION
I _think_ this is needed if you want to point `BROKER_ROOT_DIR` into Zeek's build tree after https://github.com/zeek/broker/commit/3c64a311d802348f020eaf3eda3042d4d9cb4b1d.