### PR TITLE
Use EXTRA_COMPILE_FLAGS for coverage flag

### DIFF
--- a/SetDefaultCompileFlags.cmake
+++ b/SetDefaultCompileFlags.cmake
@@ -21,8 +21,7 @@ if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
 
     if ("${_build_type_upper}" STREQUAL "DEBUG")
         if (ENABLE_COVERAGE)
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+            set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} --coverage")
         endif ()
         # manual add of -g works around its omission in FreeBSD's CMake port
         set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} -g -DDEBUG -DBRO_DEBUG")


### PR DESCRIPTION
Instead of setting `CMAKE_*_FLAGS` directly, set `EXTRA_COMPILE_FLAGS` like everything else in this file and let them get added to the CMAKE flags at the end.

Related to https://github.com/zeek/zeek/pull/3748