### PR TITLE
Don't overwrite all of CFLAGS/CXXFLAGS in prometheus-cpp build

### DIFF
--- a/FindPrometheusCpp.cmake
+++ b/FindPrometheusCpp.cmake
@@ -6,13 +6,14 @@ set(prometheuscpp_src "${CMAKE_CURRENT_SOURCE_DIR}/auxil/prometheus-cpp")
 set(_sharedlibs ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 
-# These need to be reset before setting up Prometheus because otherwise it picks up
-# the -DDEBUG from SetDefaultCompileFlags and causes civetweb to output a bunch of
-# debugging information. Let the library figure out its own flags.
+# The -DDEBUG flag from SetDefaultCompileFlags causes civetweb in prometheus-cpp
+# to output a bunch of debugging information. Remove it from the flags before
+# allowing them to pass through to the prometheus-cpp build.
 set(_cxxflags ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS "")
 set(_cflags ${CMAKE_C_FLAGS})
-set(CMAKE_C_FLAGS "")
+
+string(REPLACE "-DDEBUG" "" CMAKE_CXX_FLAGS "${_cxxflags}")
+string(REPLACE "-DDEBUG" "" CMAKE_C_FLAGS "${_cflags}")
 
 option(ENABLE_PUSH "" OFF)
 option(ENABLE_TESTING "" OFF)
@@ -25,7 +26,6 @@ message("=======================================================================
 
 set(zeekdeps ${zeekdeps} prometheus-cpp::core prometheus-cpp::pull)
 include_directories(BEFORE ${prometheuscpp_src}/pull/include ${prometheuscpp_src}/core/include)
-#include_directories(BEFORE ${prometheuscpp_src}/3rdparty/civetweb/include)
 include_directories(BEFORE ${prometheuscpp_build}/pull/include ${prometheuscpp_build}/core/include)
 
 set(BUILD_SHARED_LIBS ${_sharedlibs})


### PR DESCRIPTION
The old code overwrote CFLAGS/CXXFLAGS entirely, which removed all of the flags needed for some of the binary builds. This ensures that those flags persist, minus the one flag that was causing problems with civetweb.

Fixes https://github.com/zeek/zeek/issues/3764