### PR TITLE
Compile coverage builds with -fprofile-update=atomic

### DIFF
--- a/SetDefaultCompileFlags.cmake
+++ b/SetDefaultCompileFlags.cmake
@@ -21,7 +21,7 @@ if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
 
     if ("${_build_type_upper}" STREQUAL "DEBUG")
         if (ENABLE_COVERAGE)
-            set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} --coverage")
+            set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} --coverage -fprofile-update=atomic")
         endif ()
         # manual add of -g works around its omission in FreeBSD's CMake port
         set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} -g -DDEBUG -DBRO_DEBUG")


### PR DESCRIPTION
Running lcov on Ubuntu 24.04 on a coverage enabled build by hand produces the following error on Ubuntu 24.04:

    lcov --no-external --capture --directory . --output-file coverage.info

    Processing ./build/auxil/broker/caf/libcaf_core/CMakeFiles/libcaf_core_obj.dir/src/actor_system.cpp.gcda
    geninfo: ERROR: Unexpected negative count '-1' for /zeek/auxil/broker/caf/libcaf_core/src/actor_system.cpp:503.
        Perhaps you need to compile with '-fprofile-update=atomic
        (use "geninfo --ignore-errors negative ..." to bypass this error)

Compile with -fprofile-update=atomic for coverage enabled builds.