### PR TITLE
ZeekPluginDynamic: Handle DIST_FILES in CMake

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -159,8 +159,7 @@ function (zeek_add_dynamic_plugin ns name)
     # PROJECT_SOURCE_DIR (last project() invocation) and uses the
     # resulting path in the tarball.
     foreach (df ${FN_ARGS_DIST_FILES})
-        # set(df_src ${CMAKE_CURRENT_SOURCE_DIR}/${df})
-        get_filename_component(df_src "${df}" REALPATH)
+        get_filename_component(df_src "${df}" ABSOLUTE)
 
         if (NOT EXISTS "${df_src}")
             # This was silently ignored previously.

--- a/zeek-plugin-create-package.sh
+++ b/zeek-plugin-create-package.sh
@@ -6,27 +6,19 @@
 # Called from ZeekPluginDynamic.cmake. Current directory is the plugin
 # build directory.
 
-if [ $# = 0 ]; then
-    echo "usage: $(basename "$0") <canonical plugin name> [<additional files to include into binary distribution>]"
+if [ $# -ne 1 ]; then
+    echo "usage: $(basename "$0") <canonical plugin name>"
     exit 1
 fi
 
 name=$1
 shift
-addl=$*
 
 DIST=dist/${name}
 mkdir -p "${DIST}"
 
 # Copy files to be distributed to temporary location.
 cp -RL __zeek_plugin__ lib scripts "${DIST}"
-for i in ${addl}; do
-    if [ -e "../$i" ]; then
-        dir=$(dirname "$i")
-        mkdir -p "${DIST}/${dir}"
-        cp -p "../$i" "${DIST}/${dir}"
-    fi
-done
 
 tgz=${name}-$( (test -e ../VERSION && head -1 ../VERSION) || echo 0.0).tar.gz
 


### PR DESCRIPTION
Move path wrangling of DIST files from zeek-plugin-create-package.sh into CMake logic.

New logic: Relative paths have all leading ../ components strip to determine the location within the resulting tarball. This also removes the assumption of having build/ located within the source directory (and zeek-plugin-create-package.sh running from build/).

The quirky part is that the script deletes the produced files after creating the tarball.