### PR TITLE
Workaround for configure failures with FETCHCONTENT_FULLY_DISCONNECTED

### DIFF
--- a/ZeekBundle.cmake
+++ b/ZeekBundle.cmake
@@ -124,6 +124,7 @@ function (ZeekBundle_Add)
     FetchContent_Declare(dl_${arg_NAME} ${arg_FETCH})
     string(TOLOWER "dl_${arg_NAME}" internalName)
     FetchContent_Populate(${internalName})
+    file(MAKE_DIRECTORY "${${internalName}_BINARY_DIR}")
     # Build the package and verify that it was found.
     zeekbundle_build(${arg_NAME} "${${internalName}_SOURCE_DIR}" "${${internalName}_BINARY_DIR}"
                      ${arg_CONFIGURE})

--- a/ZeekBundle.cmake
+++ b/ZeekBundle.cmake
@@ -123,7 +123,7 @@ function (ZeekBundle_Add)
     # Fetch the package by delegating to FetchContent.
     FetchContent_Declare(dl_${arg_NAME} ${arg_FETCH})
     string(TOLOWER "dl_${arg_NAME}" internalName)
-    FetchContent_Populate(${internalName})
+    FetchContent_Populate(${internalName} SOURCE_DIR ${arg_FETCH})
     file(MAKE_DIRECTORY "${${internalName}_BINARY_DIR}")
     # Build the package and verify that it was found.
     zeekbundle_build(${arg_NAME} "${${internalName}_SOURCE_DIR}" "${${internalName}_BINARY_DIR}"


### PR DESCRIPTION
This is a band-aid fix. Ideally, we shouldn't be using `FetchContent_Populate` since it's been deprectated, and should be instead using a combination of `FetchContent_Declare` and `FetchContent_MakeAvailable`.