### PR TITLE
Use CMake variables for shared/static library suffixes

### DIFF
--- a/FindCAres.cmake
+++ b/FindCAres.cmake
@@ -12,8 +12,10 @@ if (NOT HAVE_CARES)
         find_path(CARES_ROOT_DIR NAMES "include/ares.h")
 
         # Prefer linking statically but look for a shared library version too.
-        find_library(CARES_LIBRARIES NAMES libcares_static.a libcares.so
-                     HINTS ${CARES_ROOT_DIR}/lib)
+        find_library(
+            CARES_LIBRARIES NAMES "libcares_static${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                                  "libcares${CMAKE_SHARED_LIBRARY_SUFFIX}"
+            HINTS ${CARES_ROOT_DIR}/lib)
 
         find_path(CARES_INCLUDE_DIRS NAMES "ares.h" HINTS ${CARES_ROOT_DIR}/include)
 

--- a/FindKqueue.cmake
+++ b/FindKqueue.cmake
@@ -12,8 +12,10 @@ if (NOT HAVE_KQUEUE)
         find_path(LIBKQUEUE_ROOT_DIR NAMES "include/sys/event.h")
 
         # Prefer linking statically but look for a shared library version too.
-        find_library(LIBKQUEUE_LIBRARIES NAMES libkqueue.a libkqueue.so
-                     HINTS ${LIBKQUEUE_ROOT_DIR}/lib)
+        find_library(
+            LIBKQUEUE_LIBRARIES NAMES "libkqueue${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                                      "libkqueue${CMAKE_SHARED_LIBRARY_SUFFIX}"
+            HINTS ${LIBKQUEUE_ROOT_DIR}/lib)
 
         find_path(LIBKQUEUE_INCLUDE_DIRS NAMES "sys/event.h"
                   HINTS ${LIBKQUEUE_ROOT_DIR}/include/kqueue)


### PR DESCRIPTION
I noticed this while adding Redis support to the storage framework branch. We can't hardcode `.so`/`.a` for all platforms because on Windows it's `.dll`/`.lib` and on macOS shared libraries are `.dylib`. Use CMake variables to make these checks platform-independent.