### PR TITLE
Fix some issues with finding libkrb5 and krb5.h

### DIFF
--- a/FindLibKrb5.cmake
+++ b/FindLibKrb5.cmake
@@ -17,7 +17,9 @@
 #  LibKrb5_LIBRARY                 The Krb5 library
 #  LibKrb5_INCLUDE_DIR             The location of Krb5 headers
 
-find_path(LibKrb5_ROOT_DIR NAMES include/krb5.h)
+if (NOT LibKrb5_ROOT_DIR)
+    find_path(LibKrb5_ROOT_DIR NAMES include/krb5.h)
+endif ()
 
 find_library(LibKrb5_LIBRARY NAMES krb5 HINTS ${LibKrb5_ROOT_DIR}/lib)
 

--- a/FindLibKrb5.cmake
+++ b/FindLibKrb5.cmake
@@ -23,7 +23,7 @@ endif ()
 
 find_library(LibKrb5_LIBRARY NAMES krb5 HINTS ${LibKrb5_ROOT_DIR}/lib)
 
-find_path(LibKrb5_INCLUDE_DIR NAMES krb5.h HINTS ${LibKrb5_ROOT_DIR}/include)
+find_path(LibKrb5_INCLUDE_DIR NAMES krb5/krb5.h HINTS ${LibKrb5_ROOT_DIR}/include)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibKrb5 DEFAULT_MSG LibKrb5_LIBRARY LibKrb5_INCLUDE_DIR)


### PR DESCRIPTION
This came up while fixing https://github.com/zeek/zeek/pull/4359, where searching for krb5.h on macOS defaults to the system library even if `--with-krb5` is passed to `configure`.