### PR TITLE
Report FATAL_ERROR for macOS system libkrb5

### DIFF
--- a/FindLibKrb5.cmake
+++ b/FindLibKrb5.cmake
@@ -18,12 +18,23 @@
 #  LibKrb5_INCLUDE_DIR             The location of Krb5 headers
 
 if (NOT LibKrb5_ROOT_DIR)
-    find_path(LibKrb5_ROOT_DIR NAMES include/krb5.h)
+    find_path(LibKrb5_ROOT_DIR NAMES include/krb5/krb5.h)
 endif ()
 
 find_library(LibKrb5_LIBRARY NAMES krb5 HINTS ${LibKrb5_ROOT_DIR}/lib)
 
 find_path(LibKrb5_INCLUDE_DIR NAMES krb5/krb5.h HINTS ${LibKrb5_ROOT_DIR}/include)
+
+# If using macOS, make sure that we're not finding the system's libkrb5. It
+# an old version, which points you at GSS.framework, which is also deprecated.
+if (LibKrb5_LIBRARY AND "${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+    if ("${LibKrb5_LIBRARY}" MATCHES "^/Library/Developer/CommandLineTools/SDKs/.*")
+        message(
+            FATAL_ERROR
+                "Found macOS system version of libkrb5 at ${LibKrb5_LIBRARY}. Please use the version from Homebrew instead, which is known to be more stable."
+        )
+    endif ()
+endif ()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibKrb5 DEFAULT_MSG LibKrb5_LIBRARY LibKrb5_INCLUDE_DIR)


### PR DESCRIPTION
The version of libkrb5 that comes with macOS is quite old and has problems that cause Zeek's btests to fail. Instead of blindly using it, report an error and tell the user to use the version from Homebrew. That version is known to work.