### PR TITLE
Do not leak dependencies of plugins

### DIFF
--- a/ZeekPluginDynamic.cmake
+++ b/ZeekPluginDynamic.cmake
@@ -88,7 +88,7 @@ function (zeek_add_dynamic_plugin ns name)
 
     # Add user-defined extra dependencies.
     if (FN_ARGS_DEPENDENCIES)
-        target_link_libraries(${target_name} PUBLIC ${FN_ARGS_DEPENDENCIES})
+        target_link_libraries(${target_name} PRIVATE ${FN_ARGS_DEPENDENCIES})
     endif ()
 
     # Add the sources for the plugin.

--- a/ZeekPluginStatic.cmake
+++ b/ZeekPluginStatic.cmake
@@ -81,7 +81,7 @@ function (zeek_add_static_plugin ns name)
 
     # Add extra dependencies.
     if (FN_ARGS_DEPENDENCIES)
-        target_link_libraries(${target_name} PUBLIC ${FN_ARGS_DEPENDENCIES})
+        target_link_libraries(${target_name} PRIVATE ${FN_ARGS_DEPENDENCIES})
     endif ()
 
     # Add the sources for the plugin.


### PR DESCRIPTION
Previously plugin dependencies declared with `DEPENDENCIES` would be `PUBLIC` to the plugin's target. This means that e.g., include directories from the plugin's dependency would be added to any of its dependents as well.

This not only increases the surface of what we might pull in inadvertently elsewhere, but also might cause unneeded rebuilds elsewhere if dependency paths change.

With this patch we declare any such dependencies `PRIVATE`. This should only break code which previously did not correctly declare all its dependencies. This code is used both for internal as well is external plugins, and it seems to work well for internal code. For user code this is technically a breaking change, but I expect complex CMake dependencies between multiple plugins to be rare.