### PR TITLE
Do not tweak test targets from Spicy

### DIFF
--- a/ConfigureSpicyBuild.cmake
+++ b/ConfigureSpicyBuild.cmake
@@ -12,7 +12,6 @@ set(_spicy_targets
     hilti-rt-objects
     hiltic
     jrx-objects
-    retest
     spicy-batch-extract
     spicy-config
     spicy-driver
@@ -20,7 +19,6 @@ set(_spicy_targets
     spicy-rt-debug-objects
     spicy-rt-objects
     spicyc
-    testregex
     spicy-doc
     spicy-dump)
 


### PR DESCRIPTION
auxil/spicy or more correctly its dependency justrx emitted its test targets into the build and we reconfigured them. Since we will not build these targets going forward and they will actually be unknown remove their configuration.