### PR TITLE
Link Prometheus symbols via Broker instead of directly

### DIFF
--- a/FindPrometheusCpp.cmake
+++ b/FindPrometheusCpp.cmake
@@ -24,7 +24,11 @@ message("\n==================|  prometheus-cpp Config Summary  |================
 add_subdirectory(auxil/prometheus-cpp EXCLUDE_FROM_ALL)
 message("=========================================================================\n ")
 
-set(zeekdeps ${zeekdeps} prometheus-cpp::core prometheus-cpp::pull)
+# The prometheus symbols are brought by broker, which links the libraries in statically
+# before Zeek links. We can skip linking them in ourselves as long as we are linking
+# against broker.
+#set(zeekdeps ${zeekdeps} prometheus-cpp::core prometheus-cpp::pull)
+
 include_directories(BEFORE ${prometheuscpp_src}/pull/include ${prometheuscpp_src}/core/include)
 include_directories(BEFORE ${prometheuscpp_build}/pull/include ${prometheuscpp_build}/core/include)
 


### PR DESCRIPTION
A couple of the static binary builds started failing recently due to duplicate Civetweb/Prometheus-cpp symbols. We statically link these symbols into libbroker during build, and then attempt to link them again while linking Zeek. It's strange that this hasn't come up before, but it's possible that a recent compiler upgrade became more strict about it. Stop linking them into Zeek and use the symbols from Broker. If we ever remove Broker, this line can be uncommented again.

Related to https://github.com/zeek/zeek/issues/4732