### PR TITLE
Disable warnings for C2Y extensions by default

### DIFF
--- a/SetDefaultCompileFlags.cmake
+++ b/SetDefaultCompileFlags.cmake
@@ -6,8 +6,8 @@ if (MSVC)
 endif ()
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-    set(EXTRA_COMPILE_FLAGS "-Wall -Wno-unused -funsigned-char")
-    set(EXTRA_COMPILE_FLAGS_CXX "-Wno-register -Werror=vla -funsigned-char")
+    set(EXTRA_COMPILE_FLAGS "-Wall -Wno-unused -funsigned-char -Wno-c2y-extensions")
+    set(EXTRA_COMPILE_FLAGS_CXX "-Wno-register -Werror=vla -funsigned-char -Wno-c2y-extensions")
 
     if (NOT CMAKE_BUILD_TYPE)
         if (ENABLE_DEBUG)


### PR DESCRIPTION
Building with Clang 22/23 results in a big block warnings from Broker as reported in https://github.com/zeek/broker/issues/499. We're unlikely to support C2Y (C26) any time soon, since we don't even support C23 yet. Disable the warnings for these extensions.