### PR TITLE
SetDefaultCompileFlags: Allow --coverage without --build-type=debug

### DIFF
--- a/SetDefaultCompileFlags.cmake
+++ b/SetDefaultCompileFlags.cmake
@@ -30,11 +30,12 @@ if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
 
     string(TOUPPER ${CMAKE_BUILD_TYPE} _build_type_upper)
 
+    if (ENABLE_COVERAGE)
+        set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} --coverage -fprofile-update=atomic")
+        set(EXTRA_LD_FLAGS "${EXTRA_LD_FLAGS} --coverage -fprofile-update=atomic")
+    endif ()
+
     if ("${_build_type_upper}" STREQUAL "DEBUG")
-        if (ENABLE_COVERAGE)
-            set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} --coverage -fprofile-update=atomic")
-            set(EXTRA_LD_FLAGS "${EXTRA_LD_FLAGS} --coverage -fprofile-update=atomic")
-        endif ()
         # manual add of -g works around its omission in FreeBSD's CMake port
         set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} -g -DDEBUG -DBRO_DEBUG")
     endif ()


### PR DESCRIPTION
This seems unnecessary restrictive and surprising as it silently discards `--coverage` for non debug builds. Even if coverage outside of debug builds might not be recommended, enabling it should be possible.