### PR TITLE
Build builtin Spicy analyzers with sanitizers if Zeek uses them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@
 #
 repos:
 - repo: https://github.com/cheshirekow/cmake-format-precommit
-  rev: v0.6.13
+  rev: e2c2116d86a80e72e7146a06e68b7c228afc6319  # frozen: v0.6.13
   hooks:
   - id: cmake-format
     exclude: '^(FindBISON|FindOpenSSL|FindPackageHandleStandardArgs|FindPackageMessage|SelectLibraryConfigurations|conan).cmake$'
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: trailing-whitespace
     exclude: '^(FindOpenSSL|conan).cmake$'
 
 - repo: https://github.com/maxwinterstein/shfmt-py
-  rev: v3.11.0.2
+  rev: 85cc16bc0319e182d7b62b0a2de351358083ce4c  # frozen: v4.0.0
   hooks:
     - id: shfmt
       args: ["-w", "-i", "4", "-ci"]

--- a/BuiltInSpicyAnalyzer.cmake
+++ b/BuiltInSpicyAnalyzer.cmake
@@ -95,6 +95,7 @@ function (spicy_add_analyzer)
         add_library(${lib} OBJECT ${generated_sources} ${cxx_sources})
         target_compile_features(${lib} PRIVATE ${ZEEK_CXX_STD})
         set_target_properties(${lib} PROPERTIES CXX_EXTENSIONS OFF)
+        zeek_target_enable_sanitizers(${lib})
 
         if (MSVC)
             target_compile_options(${lib} PRIVATE /bigobj /wd4716)


### PR DESCRIPTION
This is a follow-up for zeek/zeek#5561 where we switched to a
target-based approach to enable sanitizers. While doing `OBJECT`
libraries for builtin Spicy analyzers lost their potentially set
sanitizer flags which were previously set globally. Since sanitizers
usually do change the implementation of functions and types from the C
and C++ standard library this could have lead to false positive errors.

With this patch we now enable sanitizer flags for builtin Spicy
analyzers if Zeek itself was configured to use sanitizers.